### PR TITLE
Support running tests on Windows

### DIFF
--- a/changelog.d/20201212_221215_kurtmckee_os_sep.rst
+++ b/changelog.d/20201212_221215_kurtmckee_os_sep.rst
@@ -1,0 +1,6 @@
+Fixed
+.....
+
+- Support Windows' directory separator (``\``) in unit test output. (#15)
+
+  This allows the unit tests to run in Windows environments.

--- a/changelog.d/20201212_221749_kurtmckee_os_sep.rst
+++ b/changelog.d/20201212_221749_kurtmckee_os_sep.rst
@@ -1,0 +1,6 @@
+Fixed
+.....
+
+- Explicitly specify the directories and files that Black should scan. (#15)
+
+  This prevents Black from scanning every file in a virtual environment.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -147,7 +147,8 @@ def test_unknown_format():
 def test_no_such_template():
     # If you specify a template name, and it doesn't exist, an error will
     # be raised.
-    with pytest.raises(Exception, match="No such file: changelog.d/foo.j2"):
+    msg = r"No such file: changelog\.d[/\\]foo\.j2"
+    with pytest.raises(Exception, match=msg):
         Config(new_fragment_template="file: foo.j2")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands =
 deps =
     -r{toxinidir}/requirements/quality.txt
 commands =
-    black --check --diff --line-length=80 .
+    black --check --diff --line-length=80 src/scriv tests docs setup.py
     mypy src/scriv tests
     pylint src/scriv tests docs setup.py
     pycodestyle src/scriv tests docs setup.py


### PR DESCRIPTION
Hi Ned, this fixes two problems that I encountered.

First, it resolves hard-coded '/' directory separators in the unit tests -- on Windows these appear as backslashes, and now the unit tests should be flexible enough to allow for this.

Second, it explicitly specifies the directories for Black to scan. In my environment I set up a virtual environment, and Black spent a long time scanning every Python file in the virtual environment. I've separated the changes in case you don't want this change included.

Please let me know if you have any questions or want something changed or done a different way.