### PR TITLE
Respect the newline style of existing changelog files

### DIFF
--- a/changelog.d/20201213_140401_kurtmckee_newlines.rst
+++ b/changelog.d/20201213_140401_kurtmckee_newlines.rst
@@ -1,0 +1,7 @@
+Changed
+.......
+
+- Respect the existing newline style of changelog files. (#14)
+
+  This means that a changelog file with Linux newlines on a Windows platform
+  will be updated with Linux newlines, not rewritten with Windows newlines.

--- a/src/scriv/collect.py
+++ b/src/scriv/collect.py
@@ -128,8 +128,15 @@ def collect(
     sections = order_dict(sections, [None] + config.categories)
 
     changelog = Path(config.output_file)
+    newline = ""
     if changelog.exists():
-        changelog_text = changelog.read_text()
+        with changelog.open("r") as f:
+            changelog_text = f.read()
+            if f.newlines:  # .newlines may be None, str, or tuple
+                if isinstance(f.newlines, str):
+                    newline = f.newlines
+                else:
+                    newline = f.newlines[0]
         text_before, text_after = cut_at_line(
             changelog_text, config.insert_marker
         )
@@ -150,7 +157,8 @@ def collect(
     else:
         new_header = ""
     new_text = format_tools.format_sections(sections)
-    changelog.write_text(text_before + new_header + new_text + text_after)
+    with changelog.open("w", newline=newline or None) as f:
+        f.write(text_before + new_header + new_text + text_after)
 
     if edit:
         git_edit(changelog)


### PR DESCRIPTION
This patch updates scriv to follow the newline style of existing changelog files.

If no changelog file exists, scriv will fallback to Python's universal newline support so new files are created with the platform's default newline style.

Please let me know if you have any suggestions or want something done a different way.