### PR TITLE
Refactor to put API at the center

### DIFF
--- a/changelog.d/20210620_190043_nedbat_api.rst
+++ b/changelog.d/20210620_190043_nedbat_api.rst
@@ -1,0 +1,5 @@
+Added
+.....
+
+- A new poorly documented API is available.  See the Scriv, Changelog, and
+  Fragment classes in the scriv.scriv module.

--- a/src/scriv/collect.py
+++ b/src/scriv/collect.py
@@ -1,97 +1,15 @@
 """Collecting fragments."""
 
-import collections
-import datetime
-import itertools
 import logging
-from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple, TypeVar
+from typing import Optional
 
 import click
 import click_log
-import jinja2
 
-from .config import Config
-from .format import SectionDict, get_format_tools
 from .gitinfo import git_add, git_config_bool, git_edit, git_rm
+from .scriv import Scriv
 
 logger = logging.getLogger()
-
-
-def files_to_combine(config: Config) -> List[Path]:
-    """
-    Find all the files to be combined.
-
-    The files are returned in the order they should be processed.
-
-    """
-    return sorted(
-        itertools.chain.from_iterable(
-            [
-                Path(config.fragment_directory).glob(pattern)
-                for pattern in ["*.rst", "*.md"]
-            ]
-        )
-    )
-
-
-def sections_from_file(config: Config, filename: Path) -> SectionDict:
-    """
-    Collect the sections from a file.
-    """
-    format_tools = get_format_tools(filename.suffix.lstrip("."), config)
-    text = filename.read_text().rstrip()
-    file_sections = format_tools.parse_text(text)
-    return file_sections
-
-
-def combine_sections(config: Config, files: Iterable[Path]) -> SectionDict:
-    """
-    Read files, and produce a combined SectionDict of their contents.
-    """
-    sections = collections.defaultdict(list)  # type: SectionDict
-    for file in files:
-        file_sections = sections_from_file(config, file)
-        for section, paragraphs in file_sections.items():
-            sections[section].extend(paragraphs)
-    return sections
-
-
-T = TypeVar("T")
-K = TypeVar("K")
-
-
-def order_dict(
-    d: Dict[Optional[K], T], keys: Sequence[Optional[K]]
-) -> Dict[Optional[K], T]:
-    """
-    Produce an OrderedDict of `d`, but with the keys in `keys` order.
-    """
-    with_order = collections.OrderedDict()
-    to_insert = set(d)
-    for k in keys:
-        if k not in to_insert:
-            continue
-        with_order[k] = d[k]
-        to_insert.remove(k)
-
-    for k in to_insert:
-        with_order[k] = d[k]
-
-    return with_order
-
-
-def cut_at_line(text: str, marker: str) -> Tuple[str, str]:
-    """
-    Split text into two parts: up to the line with marker, and lines after.
-
-    If `marker` isn't in the text, return ("", text)
-    """
-    lines = text.splitlines(keepends=True)
-    for i, line in enumerate(lines):
-        if marker in line:
-            return "".join(lines[: i + 1]), "".join(lines[i + 1 :])
-    return ("", text)
 
 
 @click.command()
@@ -121,55 +39,27 @@ def collect(
     if edit is None:
         edit = git_config_bool("scriv.collect.edit")
 
-    config = Config.read()
-    logger.info("Collecting from {}".format(config.fragment_directory))
-    files = files_to_combine(config)
-    sections = combine_sections(config, files)
-    sections = order_dict(sections, [None] + config.categories)
+    scriv = Scriv()
+    logger.info("Collecting from {}".format(scriv.config.fragment_directory))
+    frags = scriv.fragments_to_combine()
 
-    changelog = Path(config.output_file)
-    newline = ""
-    if changelog.exists():
-        with changelog.open("r") as f:
-            changelog_text = f.read()
-            if f.newlines:  # .newlines may be None, str, or tuple
-                if isinstance(f.newlines, str):
-                    newline = f.newlines
-                else:
-                    newline = f.newlines[0]
-        text_before, text_after = cut_at_line(
-            changelog_text, config.insert_marker
-        )
-    else:
-        text_before = ""
-        text_after = ""
+    changelog = scriv.changelog()
+    changelog.read()
 
-    format_tools = get_format_tools(config.format, config)
-    title_data = {
-        "date": datetime.datetime.now(),
-        "version": version or config.version,
-    }
-    new_title = jinja2.Template(config.entry_title_template).render(
-        config=config, **title_data
-    )
-    if new_title.strip():
-        new_header = format_tools.format_header(new_title)
-    else:
-        new_header = ""
-    new_text = format_tools.format_sections(sections)
-    with changelog.open("w", newline=newline or None) as f:
-        f.write(text_before + new_header + new_text + text_after)
+    new_header = changelog.entry_header(version=version)
+    new_text = changelog.entry_text(scriv.combine_fragments(frags))
+    changelog.write(new_header, new_text)
 
     if edit:
-        git_edit(changelog)
+        git_edit(changelog.path)
 
     if add:
-        git_add(changelog)
+        git_add(changelog.path)
 
     if not keep:
-        for file in files:
-            logger.info("Deleting fragment file {}".format(file))
+        for frag in frags:
+            logger.info("Deleting fragment file {!r}".format(str(frag.path)))
             if add:
-                git_rm(file)
+                git_rm(frag.path)
             else:
-                file.unlink()
+                frag.path.unlink()

--- a/src/scriv/create.py
+++ b/src/scriv/create.py
@@ -1,52 +1,16 @@
 """Creating fragments."""
 
-import datetime
 import logging
-import re
 import sys
-import textwrap
-from pathlib import Path
 from typing import Optional
 
 import click
 import click_log
-import jinja2
 
-from .collect import sections_from_file
-from .config import Config
-from .gitinfo import (
-    current_branch_name,
-    git_add,
-    git_config_bool,
-    git_edit,
-    user_nick,
-)
+from .gitinfo import git_add, git_config_bool, git_edit
+from .scriv import Scriv
 
 logger = logging.getLogger()
-
-
-def new_fragment_path(config: Config) -> Path:
-    """
-    Return the file path for a new fragment.
-    """
-    file_name = "{:%Y%m%d_%H%M%S}_{}".format(
-        datetime.datetime.now(), user_nick()
-    )
-    branch_name = current_branch_name()
-    if branch_name and branch_name not in config.main_branches:
-        branch_name = branch_name.rpartition("/")[-1]
-        branch_name = re.sub(r"[^a-zA-Z0-9_]", "_", branch_name)
-        file_name += "_{}".format(branch_name)
-    file_name += ".{}".format(config.format)
-    file_path = Path(config.fragment_directory) / file_name
-    return file_path
-
-
-def new_fragment_contents(config: Config) -> str:
-    """Produce the initial contents of a scriv fragment."""
-    return jinja2.Template(
-        textwrap.dedent(config.new_fragment_template)
-    ).render(config=config)
 
 
 @click.command()
@@ -68,24 +32,25 @@ def create(add: Optional[bool], edit: Optional[bool]) -> None:
     if edit is None:
         edit = git_config_bool("scriv.create.edit")
 
-    config = Config.read()
-    if not Path(config.fragment_directory).exists():
+    scriv = Scriv()
+    frag = scriv.new_fragment()
+    file_path = frag.path
+    if not file_path.parent.exists():
         sys.exit(
             "Output directory {!r} doesn't exist, please create it.".format(
-                config.fragment_directory
+                str(file_path.parent)
             )
         )
 
-    file_path = new_fragment_path(config)
     if file_path.exists():
         sys.exit("File {} already exists, not overwriting".format(file_path))
 
     logger.info("Creating {}".format(file_path))
-    file_path.write_text(new_fragment_contents(config))
+    frag.write()
 
     if edit:
         git_edit(file_path)
-        sections = sections_from_file(config, file_path)
+        sections = scriv.sections_from_fragment(frag)
         if not sections:
             logger.info("Empty fragment, aborting...")
             file_path.unlink()

--- a/src/scriv/scriv.py
+++ b/src/scriv/scriv.py
@@ -1,0 +1,188 @@
+"""Central scriv class."""
+
+import collections
+import datetime
+import itertools
+import re
+import textwrap
+from pathlib import Path
+from typing import Iterable, List
+
+import attr
+import jinja2
+
+from .config import Config
+from .format import SectionDict, get_format_tools
+from .gitinfo import current_branch_name, user_nick
+from .util import cut_at_line, order_dict
+
+
+@attr.s
+class Fragment:
+    """A changelog fragment."""
+
+    path = attr.ib(type=Path)
+    format = attr.ib(type=str, default=None)
+    content = attr.ib(type=str, default=None)
+
+    def __attrs_post_init__(
+        self,
+    ):  # noqa: D105 (Missing docstring in magic method)
+        if self.format is None:
+            self.format = self.path.suffix.lstrip(".")
+
+    def write(self) -> None:
+        """Write the content to the file."""
+        self.path.write_text(self.content)
+
+    def read(self) -> None:
+        """Read the content of the fragment."""
+        self.content = self.path.read_text()
+
+
+@attr.s
+class Changelog:
+    """A changelog file."""
+
+    path = attr.ib(type=Path)
+    config = attr.ib(type=Config)
+    newline = attr.ib(type=str, default="")
+    text_before = attr.ib(type=str, default="")
+    text_after = attr.ib(type=str, default="")
+
+    def read(self) -> None:
+        """Read the changelog if it exists."""
+        if self.path.exists():
+            with self.path.open("r") as f:
+                changelog_text = f.read()
+                if f.newlines:  # .newlines may be None, str, or tuple
+                    if isinstance(f.newlines, str):
+                        self.newline = f.newlines
+                    else:
+                        self.newline = f.newlines[0]
+            self.text_before, self.text_after = cut_at_line(
+                changelog_text, self.config.insert_marker
+            )
+
+    def entry_header(self, date=None, version=None) -> str:
+        """Format the header for a new entry."""
+        format_tools = get_format_tools(self.config.format, self.config)
+        title_data = {
+            "date": date or datetime.datetime.now(),
+            "version": version or self.config.version,
+        }
+        new_title = jinja2.Template(self.config.entry_title_template).render(
+            config=self.config, **title_data
+        )
+        if new_title.strip():
+            new_header = format_tools.format_header(new_title)
+        else:
+            new_header = ""
+        return new_header
+
+    def entry_text(self, sections: SectionDict) -> str:
+        """Format the text of a new entry."""
+        format_tools = get_format_tools(self.config.format, self.config)
+        new_text = format_tools.format_sections(sections)
+        return new_text
+
+    def write(self, header: str, text: str) -> None:
+        """Write the changelog, with a new entry."""
+        with self.path.open("w", newline=self.newline or None) as f:
+            f.write(self.text_before + header + text + self.text_after)
+
+
+class Scriv:
+    """Public API to the scriv application."""
+
+    def __init__(self, *, config: Config = None):
+        """Create a new Scriv."""
+        if config is None:
+            self.config = Config.read()
+        else:
+            self.config = config
+
+    def new_fragment(self) -> Fragment:
+        """
+        Create a new fragment.
+        """
+        return Fragment(
+            format=self.config.format,
+            path=new_fragment_path(self.config),
+            content=new_fragment_content(self.config),
+        )
+
+    def fragments_to_combine(self) -> List[Fragment]:
+        """Get the list of fragments to combine."""
+        return [Fragment(path=path) for path in files_to_combine(self.config)]
+
+    def sections_from_fragment(self, fragment: Fragment) -> SectionDict:
+        """
+        Collect the sections from a fragment.
+        """
+        fragment.read()
+        format_tools = get_format_tools(fragment.format, self.config)
+        text = fragment.content.rstrip()
+        file_sections = format_tools.parse_text(text)
+        return file_sections
+
+    def combine_fragments(self, fragments: Iterable[Fragment]) -> SectionDict:
+        """
+        Read fragments and produce a combined SectionDict of their contents.
+        """
+        sections = collections.defaultdict(list)  # type: SectionDict
+        for fragment in fragments:
+            frag_sections = self.sections_from_fragment(fragment)
+            for section, paragraphs in frag_sections.items():
+                sections[section].extend(paragraphs)
+        sections = order_dict(sections, [None] + self.config.categories)
+        return sections
+
+    def changelog(self) -> Changelog:
+        """Get the Changelog object."""
+        return Changelog(
+            path=Path(self.config.output_file),
+            config=self.config,
+        )
+
+
+def new_fragment_path(config: Config) -> Path:
+    """
+    Return the file path for a new fragment.
+    """
+    file_name = "{:%Y%m%d_%H%M%S}_{}".format(
+        datetime.datetime.now(), user_nick()
+    )
+    branch_name = current_branch_name()
+    if branch_name and branch_name not in config.main_branches:
+        branch_name = branch_name.rpartition("/")[-1]
+        branch_name = re.sub(r"[^a-zA-Z0-9_]", "_", branch_name)
+        file_name += "_{}".format(branch_name)
+    file_name += ".{}".format(config.format)
+    file_path = Path(config.fragment_directory) / file_name
+    return file_path
+
+
+def new_fragment_content(config: Config) -> str:
+    """Produce the initial content of a scriv fragment."""
+    return jinja2.Template(
+        textwrap.dedent(config.new_fragment_template)
+    ).render(config=config)
+
+
+def files_to_combine(config: Config) -> List[Path]:
+    """
+    Find all the fragment file paths to be combined.
+
+    The paths are returned in the order they should be processed.
+
+    """
+    paths = sorted(
+        itertools.chain.from_iterable(
+            [
+                Path(config.fragment_directory).glob(pattern)
+                for pattern in ["*.rst", "*.md"]
+            ]
+        )
+    )
+    return paths

--- a/src/scriv/util.py
+++ b/src/scriv/util.py
@@ -1,0 +1,43 @@
+"""Miscellanous helpers."""
+
+import collections
+from typing import Dict, Optional, Sequence, Tuple, TypeVar
+
+T = TypeVar("T")
+K = TypeVar("K")
+
+
+def order_dict(
+    d: Dict[Optional[K], T], keys: Sequence[Optional[K]]
+) -> Dict[Optional[K], T]:
+    """
+    Produce an OrderedDict of `d`, but with the keys in `keys` order.
+
+    Keys in `d` that don't appear in `keys` will be at the end in an
+    undetermined order.
+    """
+    with_order = collections.OrderedDict()
+    to_insert = set(d)
+    for k in keys:
+        if k not in to_insert:
+            continue
+        with_order[k] = d[k]
+        to_insert.remove(k)
+
+    for k in to_insert:
+        with_order[k] = d[k]
+
+    return with_order
+
+
+def cut_at_line(text: str, marker: str) -> Tuple[str, str]:
+    """
+    Split text into two parts: up to the line with marker, and lines after.
+
+    If `marker` isn't in the text, return ("", text)
+    """
+    lines = text.splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        if marker in line:
+            return "".join(lines[: i + 1]), "".join(lines[i + 1 :])
+    return ("", text)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -6,20 +6,20 @@ from pathlib import Path
 import freezegun
 
 from scriv.config import Config
-from scriv.create import new_fragment_contents, new_fragment_path
+from scriv.scriv import Scriv
 
 
 class TestNewFragmentPath:
     """
-    Tests of scriv.create.new_fragment_path.
+    Tests of the paths of new fragments.
     """
 
     @freezegun.freeze_time("2012-10-01T07:08:09")
     def test_new_fragment_path(self, fake_git):
         fake_git.set_config("github.user", "joedev")
         fake_git.set_branch("master")
-        config = Config(fragment_directory="notes")
-        assert new_fragment_path(config) == Path(
+        scriv = Scriv(config=Config(fragment_directory="notes"))
+        assert scriv.new_fragment().path == Path(
             "notes/20121001_070809_joedev.rst"
         )
 
@@ -27,10 +27,12 @@ class TestNewFragmentPath:
     def test_new_fragment_path_with_custom_main(self, fake_git):
         fake_git.set_config("github.user", "joedev")
         fake_git.set_branch("mainline")
-        config = Config(
-            fragment_directory="notes", main_branches=["main", "mainline"]
+        scriv = Scriv(
+            config=Config(
+                fragment_directory="notes", main_branches=["main", "mainline"]
+            )
         )
-        assert new_fragment_path(config) == Path(
+        assert scriv.new_fragment().path == Path(
             "notes/20121001_070809_joedev.rst"
         )
 
@@ -38,50 +40,50 @@ class TestNewFragmentPath:
     def test_new_fragment_path_with_branch(self, fake_git):
         fake_git.set_config("github.user", "joedev")
         fake_git.set_branch("joedeveloper/feature-123.4")
-        config = Config(fragment_directory="notes")
-        assert new_fragment_path(config) == Path(
+        scriv = Scriv(config=Config(fragment_directory="notes"))
+        assert scriv.new_fragment().path == Path(
             "notes/20130225_151617_joedev_feature_123_4.rst"
         )
 
 
-class TestNewFragmentContents:
+class TestNewFragmentContent:
     """
-    Tests of scriv.create.new_fragment_contents.
+    Tests of the content of new fragments.
     """
 
     def test_new_fragment_contents_rst(self):
-        config = Config(format="rst")
-        contents = new_fragment_contents(config)
-        assert contents.startswith(".. ")
-        assert ".. A new scriv changelog fragment" in contents
-        assert ".. Added\n.. -----\n" in contents
-        assert all(cat in contents for cat in config.categories)
+        scriv = Scriv(config=Config(format="rst"))
+        content = scriv.new_fragment().content
+        assert content.startswith(".. ")
+        assert ".. A new scriv changelog fragment" in content
+        assert ".. Added\n.. -----\n" in content
+        assert all(cat in content for cat in scriv.config.categories)
 
     def test_new_fragment_contents_rst_with_customized_header(self):
-        config = Config(format="rst", rst_header_chars="#~")
-        contents = new_fragment_contents(config)
-        assert contents.startswith(".. ")
-        assert ".. A new scriv changelog fragment" in contents
-        assert ".. Added\n.. ~~~~~\n" in contents
-        assert all(cat in contents for cat in config.categories)
+        scriv = Scriv(config=Config(format="rst", rst_header_chars="#~"))
+        content = scriv.new_fragment().content
+        assert content.startswith(".. ")
+        assert ".. A new scriv changelog fragment" in content
+        assert ".. Added\n.. ~~~~~\n" in content
+        assert all(cat in content for cat in scriv.config.categories)
 
     def test_no_categories_rst(self, changelog_d):
         # If the project isn't using categories, then the new fragment is
         # simpler with no heading.
-        config = Config(categories=[])
-        contents = new_fragment_contents(config)
-        assert ".. A new scriv changelog fragment." in contents
-        assert "- A bullet item for this fragment. EDIT ME!" in contents
-        assert "Uncomment the header that is right" not in contents
-        assert ".. Added" not in contents
+        scriv = Scriv(config=Config(categories=[]))
+        content = scriv.new_fragment().content
+        assert ".. A new scriv changelog fragment." in content
+        assert "- A bullet item for this fragment. EDIT ME!" in content
+        assert "Uncomment the header that is right" not in content
+        assert ".. Added" not in content
 
     def test_new_fragment_contents_md(self):
-        config = Config(format="md")
-        contents = new_fragment_contents(config)
-        assert contents.startswith("<!--")
-        assert "A new scriv changelog fragment" in contents
-        assert "### Added\n" in contents
-        assert all(cat in contents for cat in config.categories)
+        scriv = Scriv(config=Config(format="md"))
+        content = scriv.new_fragment().content
+        assert content.startswith("<!--")
+        assert "A new scriv changelog fragment" in content
+        assert "### Added\n" in content
+        assert all(cat in content for cat in scriv.config.categories)
 
 
 class TestCreate:


### PR DESCRIPTION
This is a work in progress.

The code has been refactored to produce a public API in the classes in scriv.py (Fragment, Changelog, and Scriv).  The create and collect CLI commands use the API.

Some things that are not yet done:
- Documentation. Even the docstrings are just single-line notes.
- I'm not sure what to do about logging.  The API doesn't log. Is that OK?
- Checks for missing directories and overwriting existing fragments are in the CLI code, not the API.  Is that right?

The big question of course: is this a useful API?  Does it match your idea of what it should be shaped like?