### PR TITLE
Ensure the changelog is in UTF-8

### DIFF
--- a/src/scriv/collect.py
+++ b/src/scriv/collect.py
@@ -130,7 +130,7 @@ def collect(
     changelog = Path(config.output_file)
     newline = ""
     if changelog.exists():
-        with changelog.open("r") as f:
+        with changelog.open("r", encoding="utf-8") as f:
             changelog_text = f.read()
             if f.newlines:  # .newlines may be None, str, or tuple
                 if isinstance(f.newlines, str):
@@ -157,7 +157,7 @@ def collect(
     else:
         new_header = ""
     new_text = format_tools.format_sections(sections)
-    with changelog.open("w", newline=newline or None) as f:
+    with changelog.open("w", encoding="utf-8", newline=newline or None) as f:
         f.write(text_before + new_header + new_text + text_after)
 
     if edit:

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -336,7 +336,7 @@ def test_collect_version_in_config(cli_invoke, changelog_d, temp_dir):
     (changelog_d / "20170616_nedbat.rst").write_text("- The first change.\n")
     with freezegun.freeze_time("2020-02-26T15:18:19"):
         cli_invoke(["collect"])
-    changelog_text = changelog.read_text()
+    changelog_text = changelog.read_text(encoding="utf-8")
     expected = (
         "\n"
         + "v12.34b — 2020-02-26\n"


### PR DESCRIPTION
The default encoding may not be UTF-8, especially for Windows. The "—" between the date and version in the title may be encoded as non-UTF-8 character when different encoding is used, e.g.  windows-1252.