### PR TITLE
fix: ensure the changelog is in UTF-8

### DIFF
--- a/changelog.d/20210622_192022_nedbat_replace_31.rst
+++ b/changelog.d/20210622_192022_nedbat_replace_31.rst
@@ -1,0 +1,5 @@
+Fixed
+.....
+
+- The changelog is now always written as UTF-8, regardless of the default
+  encoding of the system.  Thanks, Hei (yhlam).

--- a/src/scriv/scriv.py
+++ b/src/scriv/scriv.py
@@ -53,7 +53,7 @@ class Changelog:
     def read(self) -> None:
         """Read the changelog if it exists."""
         if self.path.exists():
-            with self.path.open("r") as f:
+            with self.path.open("r", encoding="utf-8") as f:
                 changelog_text = f.read()
                 if f.newlines:  # .newlines may be None, str, or tuple
                     if isinstance(f.newlines, str):
@@ -88,7 +88,9 @@ class Changelog:
 
     def write(self, header: str, text: str) -> None:
         """Write the changelog, with a new entry."""
-        with self.path.open("w", newline=self.newline or None) as f:
+        with self.path.open(
+            "w", encoding="utf-8", newline=self.newline or None
+        ) as f:
             f.write(self.text_before + header + text + self.text_after)
 
 

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -336,7 +336,7 @@ def test_collect_version_in_config(cli_invoke, changelog_d, temp_dir):
     (changelog_d / "20170616_nedbat.rst").write_text("- The first change.\n")
     with freezegun.freeze_time("2020-02-26T15:18:19"):
         cli_invoke(["collect"])
-    changelog_text = changelog.read_text()
+    changelog_text = changelog.read_text(encoding="utf-8")
     expected = (
         "\n"
         + "v12.34b — 2020-02-26\n"


### PR DESCRIPTION
This is a re-application of the fix provided by yhlam in pull request #31.