### PR TITLE
Support finding version info in TOML files (#44)

### DIFF
--- a/changelog.d/20211206_074117_kurtmckee_toml_versions.rst
+++ b/changelog.d/20211206_074117_kurtmckee_toml_versions.rst
@@ -1,0 +1,5 @@
+Added
+.....
+
+-   Support finding version information in TOML files (like ``pyproject.toml``)
+    using the ``literal`` configuration directive.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -65,7 +65,7 @@ It is also possible to specify a variable in a TOML file
 using periods to separate the sections and key names::
 
     [scriv]
-    version = literal: pyproject.toml: tool.poetry.version
+    version = literal: pyproject.toml: project.version
 
 Currently only Python and TOML files are supported for literals,
 but other syntaxes can be supported in the future.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -61,8 +61,14 @@ separated by colons::
 In this case, the file ``myproj/__init__.py`` will be read, and the
 ``__version__`` value will be found and used as the version setting.
 
-Currently only Python files are supported for literals, but other syntaxes
-can be supported in the future.
+It is also possible to specify a variable in a TOML file
+using periods to separate the sections and key names::
+
+    [scriv]
+    version = literal: pyproject.toml: tool.poetry.version
+
+Currently only Python and TOML files are supported for literals,
+but other syntaxes can be supported in the future.
 
 Value Substitution
 ------------------


### PR DESCRIPTION
This patch adds support for extracting version information from TOML files. For example, projects using Poetry can specify the following version literal in their `pyproject.toml` file:

```toml
[tool.scriv]
version = "literal: pyproject.toml: tool.poetry.version"

# PEP 621 example:
# version = "literal: pyproject.toml: project.version"
```

Then project metadata can be managed using Poetry and doesn't have to be extracted and passed to scriv separately:

```shell
poetry version minor
scriv collect
```

# Changelog

Added
-------

-   Support finding version information in TOML files (like ``pyproject.toml``)
    using the ``literal`` configuration directive.
