### PR TITLE
fix: place .md anchors immediately before title

### DIFF
--- a/src/scriv/format_md.py
+++ b/src/scriv/format_md.py
@@ -60,7 +60,7 @@ class MdTools(FormatTools):
         num = int(self.config.md_header_level)
         header = "\n"
         if anchor:
-            header += f"<a id='{anchor}'/>\n"
+            header += f"<a id='{anchor}'></a>\n"
         header += "#" * num + " " + text + "\n"
         return header
 

--- a/src/scriv/format_md.py
+++ b/src/scriv/format_md.py
@@ -60,7 +60,7 @@ class MdTools(FormatTools):
         num = int(self.config.md_header_level)
         header = "\n"
         if anchor:
-            header += f"<a id='{anchor}'/>\n\n"
+            header += f"<a id='{anchor}'/>\n"
         header += "#" * num + " " + text + "\n"
         return header
 


### PR DESCRIPTION
Hey!

I am going to go out on a limb here and assume that you decided to place a blank line between the `<a .. />` anchor and the title because of your experience with `.rst` files.
However, as far as I can tell, `.md` files typically have their anchors _next_ to the titles. This is pretty much a matter of style, so I reckon the chances of this PR being rejected are high, but I thought it wouldn't hurt to try!

Thanks for your work on `scriv`.