### PR TITLE
[Enhancement] CFF and bump2version (#1)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,11 @@
+[bumpversion]
+current_version = 0.17.0
+message = Version {new_version}
+tag_message =
+tag_name = {new_version}
+
+[bumpversion:file:CITATION.cff]
+replace: version: {new_version}
+search: version: {current_version}
+
+[bumpversion:file:setup.py]

--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -1,0 +1,24 @@
+name: cffconvert
+
+on:
+  push:
+    paths:
+      - CITATION.cff
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          persist-credentials: false
+
+      - name: cffconvert
+        uses: citation-file-format/cffconvert-github-action@4cf11baa70a673bfdf9dad0acc7ee33b3f4b6084
+        with:
+          args: "--validate"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,28 @@
+# Parser settings.
+cff-version: 1.2.0
+message: Please cite this software using these meta data.
+
+# Version information.
+date-released: 2022-09-19
+version: 0.17.0
+
+# Project information.
+abstract: Changelog management tool
+authors:
+  - alias: nedbat
+    family-names: Batchelder
+    given-names: Ned
+  - alias: kurtmckee
+    family-names: McKee
+    given-names: Kurt
+  - alias: maxking
+    family-names: Raj
+    given-names: Abhilash
+  - alias: rodrigogiraoserrao
+    family-names: Serrão
+    given-names: Rodrigo Girão
+license: Apache-2.0
+repository-artifact: https://pypi.python.org/pypi/scriv/
+repository-code: https://github.com/nedbat/scriv
+title: Scriv
+url: https://github.com/nedbat/scriv


### PR DESCRIPTION
### Summary

This Pull Request introduces support for CFF and bump2version.

### CFF

#### About

[CFF](https://github.com/citation-file-format/citation-file-format) is a standard in order to cite software.  Repositories equipped with a valid CITATION.cff can be cited in papers and theses just like books and articles.  Also when recommending a project to others, CFF will come in handy.  The citation meta data can be converted to APA and BibTeX entries for a list of references.

One can not only maintain a list of contributors as many open source projects do but also give a list of consulted references and further readings for the interested, respectively.

This CITATION.cff comes with a validation Action in order to ensure its correctness.  The initial meta data is derived from the repository.  The CITATION.cff is valid according to schema version 1.2.0 (latest).  The Action is known to succeed in about 10 seconds, the whole run takes approximately 30 seconds.

#### References

Druskat, S., Spaaks, J. H., Chue Hong, N., Haines, R., Baker, J., Bliven, S., Willighagen, E., Pérez-Suárez, D., & Konovalov, A. (2021). Citation File Format (Version 1.2.0) [Computer software]. https://doi.org/10.5281/zenodo.5171937

### bump2version

#### About

bump2version is a free and open source Python 3 CLI which helps to auto-increment the version number of a software.  It is licensed MIT and available via the Python Package Index.  The behaviour of the application is controlled by a configuration file named `.bumpversion.cfg` and stored in the repository root.  This configuration file is self-maintaining.  Whenever one needs to increment the version of the project prior to a new release, bump2version will update all registered files as well as its own configuration file ("self-maintaining").

bump2version also offers auto-committing and auto-tagging the new version.  This would enhance the current release build step in the makefile.  The messages are set to the conventions derived from the recent Git History.  Auto-committing and auto-tagging is invoked by calling the application as follows:

```bash
bump2version --commit --tag patch # update to 0.17.1
bump2version --commit --tag minor # update to 0.18.0
bump2version --commit --tag major # update to 1.0.0
```

Without the `--commit` and `--tag` options, the respective functionalities are not invoked.  To enable them permanently, the corresponding settings can be added to the configuration file.

```
[bumpversion]
commit = True
tag = True
```

Please consult the [official README](https://github.com/c4urself/bump2version/blob/master/README.md) for further information on configuration as well as practical examples.

#### References

Verkerk, C., & The bump2version Community. (2020). bump2version (Version 1.0.2-dev) [Computer software]. https://github.com/c4urself/bump2version

### Conclusion

This Pull Request is intended to enhance the documentation (CFF features) as well as the maintenance workflow (bump2version setup) of this project.  Since the suggested changes are initial setups of the respective technologies for further discussion, I did not create a corresponding changelog entry, yet.  As soon as both the citation meta data as well as the bump2version configuration are agreed on, I am going to submit the changelog entry, as well.