### PR TITLE
Use tomllib on python 3.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ console_scripts =
     scriv = scriv.cli:cli
 
 [options.extras_require]
-toml = tomli
+toml = tomli;python_version<'3.11'
 yaml = pyyaml
 
 [scriv]

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ console_scripts =
     scriv = scriv.cli:cli
 
 [options.extras_require]
-toml = tomli;python_version<'3.11'
+toml = tomli;python_version<3.11
 yaml = pyyaml
 
 [scriv]

--- a/src/scriv/config.py
+++ b/src/scriv/config.py
@@ -11,7 +11,7 @@ import attr
 try:
     import tomllib as tomli
 except ModuleNotFoundError:  # pragma: no cover
-    import tomli
+    import tomli  # type: ignore
 except ImportError:  # pragma: no cover
     tomli = None  # type: ignore
 

--- a/src/scriv/config.py
+++ b/src/scriv/config.py
@@ -9,6 +9,8 @@ from typing import Any, List
 import attr
 
 try:
+    import tomllib as tomli
+except ModuleNotFoundError:  # pragma: no cover
     import tomli
 except ImportError:  # pragma: no cover
     tomli = None  # type: ignore

--- a/src/scriv/literals.py
+++ b/src/scriv/literals.py
@@ -9,7 +9,7 @@ from typing import Any, MutableMapping, Optional
 try:
     import tomllib as tomli
 except ModuleNotFoundError:  # pragma: no cover
-    import tomli
+    import tomli  # type: ignore
 except ImportError:  # pragma: no cover
     tomli = None  # type: ignore
 

--- a/src/scriv/literals.py
+++ b/src/scriv/literals.py
@@ -7,6 +7,8 @@ import os.path
 from typing import Any, MutableMapping, Optional
 
 try:
+    import tomllib as tomli
+except ModuleNotFoundError:  # pragma: no cover
     import tomli
 except ImportError:  # pragma: no cover
     tomli = None  # type: ignore


### PR DESCRIPTION
This pr tries to solve the following issue: Python3.11, we can use the stdlib toml library #60. 

I tried to modify the code as little as possible, hope it helps :)