### PR TITLE
Reduce CI usage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
         uses: "actions/checkout@v3"
 
       - name: "Set up Python"
+        id: "setup-python"
         uses: "actions/setup-python@v4"
         with:
           # The last listed Python version is the default.
@@ -47,13 +48,26 @@ jobs:
             3.9
             3.10
             3.11
-          cache: pip
-          cache-dependency-path: 'requirements/*.txt'
+
+      - name: "Restore cache"
+        id: "restore-cache"
+        uses: "actions/cache@v3"
+        with:
+          path: |
+            .tox/
+            .venv/
+          key: "cache-python-${{ steps.setup-python.outputs.python-version }}-os-${{ runner.os }}-hash-${{ hashFiles('tox.ini', 'requirements/*.txt') }}"
+
+      - name: "Identify venv path"
+        shell: "bash"
+        run: "echo 'venv-path=${{ runner.os == 'Windows' && '.venv/Scripts' || '.venv/bin' }}' >> $GITHUB_ENV"
 
       - name: "Install dependencies"
+        if: "steps.restore-cache.outputs.cache-hit == false"
         run: |
-          python -m pip install -U setuptools
-          python -m pip install -r requirements/tox.txt
+          python -m venv .venv
+          ${{ env.venv-path }}/python -m pip install -U setuptools
+          ${{ env.venv-path }}/python -m pip install -r requirements/tox.txt
 
       - name: "Install pandoc on Linux"
         # sudo apt-get pandoc: will install a version from 2018!
@@ -74,7 +88,7 @@ jobs:
 
       - name: "Run tox"
         run: |
-          python -m tox -m ci-tests
+          ${{ env.venv-path }}/python -m tox -m ci-tests
 
       - name: "Upload coverage data"
         uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   tests:
-    name: "${{ matrix.python-version }} on ${{ matrix.os }}"
+    name: "Test on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}-latest"
 
     strategy:
@@ -31,13 +31,6 @@ jobs:
           - ubuntu
           - macos
           - windows
-        python-version:
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "pypy-3.9"
 
     steps:
       - name: "Check out the repo"
@@ -46,7 +39,14 @@ jobs:
       - name: "Set up Python"
         uses: "actions/setup-python@v4"
         with:
-          python-version: "${{ matrix.python-version }}"
+          # The last listed Python version is the default.
+          python-version: |
+            pypy-3.9
+            3.7
+            3.8
+            3.9
+            3.10
+            3.11
           cache: pip
           cache-dependency-path: 'requirements/*.txt'
 
@@ -72,9 +72,9 @@ jobs:
         run: |
           choco install -y -r --no-progress pandoc
 
-      - name: "Run tox for ${{ matrix.python-version }}"
+      - name: "Run tox"
         run: |
-          python -m tox
+          python -m tox -m ci-tests
 
       - name: "Upload coverage data"
         uses: actions/upload-artifact@v3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -366,9 +366,6 @@ tomlkit==0.11.8
 tox==4.6.4
     # via
     #   -r requirements/tox.txt
-    #   tox-gh
-tox-gh==1.2.0
-    # via -r requirements/tox.txt
 twine==4.0.2
     # via -r requirements/quality.txt
 typed-ast==1.5.5

--- a/requirements/tox.in
+++ b/requirements/tox.in
@@ -2,4 +2,3 @@
 -c constraints.txt
 
 tox                       # Virtualenv management for tests
-tox-gh                    # Run tox environment based on the GitHub action matrix

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -40,9 +40,6 @@ tomli==2.0.1
 tox==4.6.4
     # via
     #   -r requirements/tox.in
-    #   tox-gh
-tox-gh==1.2.0
-    # via -r requirements/tox.in
 typing-extensions==4.7.1
     # via
     #   importlib-metadata

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ labels =
     ci-tests = py3{7,8,9,10,11},pypy3
 
 [testenv]
+package = wheel
+wheel_build_env = .pkg
 deps =
     -r{toxinidir}/requirements/test.txt
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ envlist =
     py3{7,11}-no_extras,
     # And the rest:
     pypy3, coverage, docs, quality
+labels =
+    ci-tests = py3{7,8,9,10,11},pypy3
 
 [testenv]
 deps =
@@ -61,13 +63,3 @@ commands =
 commands =
     python -m pip install -U pip
     make upgrade
-
-[gh]
-# https://pypi.org/project/tox-gh/
-python =
-    3.7 = py37, py37-no_extras
-    3.8 = py38
-    3.9 = py39
-    3.10 = py310
-    3.11 = py311, py311-no_extras
-    pypy3 = pypy3


### PR DESCRIPTION
This PR reduces the total usage in CI (that is, the sum of time across all jobs that run).

Currently, CI usage is **~30 minutes**.
Without a cache hit, that number is dropped to **~15 minutes**.
With a cache hit, that number drops to **~10 minutes**.

The CI duration (the amount of time for the entire workflow to run while you're staring at a wall clock) stays roughly the same (~5 minutes).

This is achieved by reducing the number of test runners to just one of each OS testing all Python versions simultaneously. (The `setup-python` action now supports setting up multiple Python versions!) This reduces the duplication of activities that are unrelated to the actual testing. For example, checking out the repo and installing pandoc.

In addition, time is saved by building a wheel once, rather than building a `.tar.gz` that each Python version-specific `pip` invocation quietly converts to a wheel in the background.

Finally, a virtual environment is created and cached, and the tox environments are cached as well. This reduces the setup time required to actually launch the tests.

_Note: The cache of the tox environment may get rebuilt by tox when a Python version has a hotfix bump, like 3.10.x to 3.10.y. A possible improvement to this would be to write the Python versions to a file and include that in the call to `hashFiles()`._