### PR TITLE
literal: add support for .cfg file (like setup.cfg)

### DIFF
--- a/src/scriv/literals.py
+++ b/src/scriv/literals.py
@@ -3,6 +3,7 @@ Find literals in various kinds of files.
 """
 
 import ast
+import configparser
 import os.path
 from typing import Any, MutableMapping, Optional
 
@@ -43,6 +44,10 @@ def find_literal(file_name: str, literal_name: str) -> Optional[str]:
         with open(file_name, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         return find_nested_value(data, literal_name)
+    elif ext == ".cfg":
+        cfg_parser = configparser.ConfigParser()
+        cfg_parser.read(file_name)
+        return find_nested_value(cfg_parser, literal_name)
     else:
         raise ScrivException(
             f"Can't read literals from files like {file_name!r}"

--- a/tests/test_literals.py
+++ b/tests/test_literals.py
@@ -155,3 +155,47 @@ def test_find_yaml_literal_fail_if_unavailable(monkeypatch):
         ScrivException, match="Can't read .+ without YAML support"
     ):
         find_literal("foo.yml", "fail")
+
+
+CFG_LITERAL = """\
+
+[metadata]
+name = myproduct
+version = 1.2.3
+url = https://github.com/nedbat/scriv
+description = A nice description
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = MIT
+
+[options]
+zip_safe = false
+include_package_data = true
+
+[bdist_wheel]
+universal = true
+
+[coverage:report]
+show_missing = true
+
+[flake8]
+max-line-length = 99
+doctests = True
+exclude =  .git, .eggs, __pycache__, tests/, docs/, build/, dist/
+"""
+
+
+@pytest.mark.parametrize(
+    "name, value",
+    [
+        ("metadata.version", "1.2.3"),
+        ("options.zip_safe", "false"),
+        ("coverage:report", None),  # find_literal only supports string values
+        ("metadata.myVersion", None),
+        ("unexisting", None),
+    ],
+)
+def test_find_cfg_literal(name, value, temp_dir):
+    with open("foo.cfg", "w", encoding="utf-8") as f:
+        f.write(CFG_LITERAL)
+    assert find_literal("foo.cfg", name) == value


### PR DESCRIPTION
I would like to propose the ability to extract version or other information from setup.cfg, not only project.toml or yaml files.

This time with a test !