### PR TITLE
Update Installation Instructions in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,21 +29,25 @@ It allows you to install and run Python applications in isolated environments,
 preventing conflicts between dependencies and ensuring that each application
 uses its own set of packages.
 
-1. First, install ``pipx`` if you haven't already:
+**1.** First, install ``pipx`` if you haven't already:
 
-* On macOS and Linux::
+**On macOS and Linux:**
+
+::
 
   python3 -m pip install --user pipx
   python3 -m pipx ensurepath
 
 Alternatively, you can use your package manager (``brew``, ``apt``, etc.).
 
-* On Windows::
+**On Windows:**
+
+::
 
   py -m pip install --user pipx
   py -m pipx ensurepath
 
-2. Once ``pipx`` is installed, you can install scriv using the following command::
+**2.** Once ``pipx`` is installed, you can install scriv using the following command::
 
   pipx install scriv
 

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,39 @@ Scriv is a command-line tool for helping developers maintain useful changelogs.
 It manages a directory of changelog fragments. It aggregates them into entries
 in a CHANGELOG file.
 
+Installation
+============
+
+To install scriv, you can use the following command::
+
+  python3 -m pip install scriv
+
+Install via `pipx <https://pypi.org/project/pipx/>`_ (recommended)
+-----------------------------------------------------------------
+
+``pipx`` is an alternative package manager for Python applications.
+It allows you to install and run Python applications in isolated environments,
+preventing conflicts between dependencies and ensuring that each application
+uses its own set of packages.
+
+1. First, install ``pipx`` if you haven't already:
+
+  * On macOS and Linux::
+
+    python3 -m pip install --user pipx
+    python3 -m pipx ensurepath
+
+Alternatively, you can use your package manager (``brew``, ``apt``, etc.).
+
+  * On Windows::
+
+    py -m pip install --user pipx
+    py -m pipx ensurepath
+
+2. Once ``pipx`` is installed, you can install scriv using the following command::
+
+  pipx install scriv
+
 Getting Started
 ===============
 

--- a/README.rst
+++ b/README.rst
@@ -31,17 +31,17 @@ uses its own set of packages.
 
 1. First, install ``pipx`` if you haven't already:
 
-  * On macOS and Linux::
+* On macOS and Linux::
 
-    python3 -m pip install --user pipx
-    python3 -m pipx ensurepath
+  python3 -m pip install --user pipx
+  python3 -m pipx ensurepath
 
 Alternatively, you can use your package manager (``brew``, ``apt``, etc.).
 
-  * On Windows::
+* On Windows::
 
-    py -m pip install --user pipx
-    py -m pipx ensurepath
+  py -m pip install --user pipx
+  py -m pipx ensurepath
 
 2. Once ``pipx`` is installed, you can install scriv using the following command::
 


### PR DESCRIPTION
This pull request updates the installation instructions in README.rst to provide more detailed steps. Specifically, it adds instructions for installing the application using `pipx`.

Changes include:

* A new section explaining what `pipx` is and why it's recommended.
* Step-by-step instructions for installing pipx on macOS/Linux and Windows.
* Instructions for installing `scriv` once `pipx` is installed.

These changes provide more complete instructions for installing the application, making it easier for new users to get started.

