### PR TITLE
Add explicit error for invalid versions encountered during collect

### DIFF
--- a/src/scriv/collect.py
+++ b/src/scriv/collect.py
@@ -71,6 +71,11 @@ def collect(
                 if etitle is None:
                     continue
                 eversion = Version.from_text(etitle)
+                if eversion is None:
+                    sys.exit(
+                        f"Entry {etitle!r} is not a valid version! "
+                         + "If scriv should ignore this heading, add 'scriv-end-here' somewhere before it"
+                    )
                 if eversion == version:
                     sys.exit(
                         f"Entry {etitle!r} already uses "

--- a/src/scriv/collect.py
+++ b/src/scriv/collect.py
@@ -74,7 +74,8 @@ def collect(
                 if eversion is None:
                     sys.exit(
                         f"Entry {etitle!r} is not a valid version! "
-                         + "If scriv should ignore this heading, add 'scriv-end-here' somewhere before it"
+                        + "If scriv should ignore this heading, add "
+                        + "'scriv-end-here' somewhere before it."
                     )
                 if eversion == version:
                     sys.exit(


### PR DESCRIPTION
Fixes #100

This changeset adds an explicit error message when `scriv` encounters an invalid version while running the `collect` command, including a hint to use `scriv-end-here` to mark the end of the part of a changelog that `scriv` should consider.