### PR TITLE
fix: don't strip trailing newlines when rendering fragment templates

### DIFF
--- a/changelog.d/20231210_233839_dpb_keep_trailing_newline.rst
+++ b/changelog.d/20231210_233839_dpb_keep_trailing_newline.rst
@@ -1,0 +1,7 @@
+Fixed
+.....
+
+- A final newline is no longer stripped when rendering the new fragment
+  template, fixing `issue 108`_.
+
+.. _issue 108: https://github.com/nedbat/scriv/issues/108

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     attrs
     click
     click-log
-    jinja2
+    jinja2>=2.7
     markdown-it-py
     requests
 # end_install_requires

--- a/src/scriv/scriv.py
+++ b/src/scriv/scriv.py
@@ -90,7 +90,8 @@ def _new_fragment_path(config: Config) -> Path:
 def _new_fragment_content(config: Config) -> str:
     """Produce the initial content of a scriv fragment."""
     return jinja2.Template(
-        textwrap.dedent(config.new_fragment_template)
+        textwrap.dedent(config.new_fragment_template),
+        keep_trailing_newline=True,
     ).render(config=config)
 
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -85,6 +85,14 @@ class TestNewFragmentContent:
         assert "### Added\n" in content
         assert all(cat in content for cat in scriv.config.categories)
 
+    def test_final_newline_in_template_preserved(self, changelog_d):
+        (changelog_d / "new_fragment.j2").write_text("Custom template.\n")
+        scriv = Scriv(
+            config=Config(new_fragment_template="file: new_fragment.j2")
+        )
+        content = scriv.new_fragment().content
+        assert content == "Custom template.\n"
+
 
 class TestCreate:
     """


### PR DESCRIPTION
If a fragment template ends with a newline, then created fragments should end with one too.

The `keep_trailing_newline` parameter was added in Jinja 2.7, so update the dependency.

Fixes #108.
