### PR TITLE
Fix an incorrect statement in philosophy about Towncrier only supporting RST

### DIFF
--- a/docs/philosophy.rst
+++ b/docs/philosophy.rst
@@ -37,7 +37,9 @@ None fully embodied scriv's philopsophy.
 Tools most similar to scriv:
 
 - `towncrier`_: built for Twisted, with some unusual specifics: fragment type
-  is the file extension, issue numbers in the file name.  Only .rst files.
+  is the file extension, issue numbers in the file name.  Defaults to using
+  ``.rst`` files, but can be configured to produce Markdown or any other
+  output format, provided enough configuration.
 
 - `blurb`_: built for CPython development, specific to their workflow: issue
   numbers from bugs.python.org, only .rst files.


### PR DESCRIPTION
The reality is that it is Jinja2 template based and can produce Markdown as well. It just used to be poorly documented. I helped Hynek figure it out for the attrs project at some point.