### PR TITLE
Uncap pylint-pytest in the dependency lists and lock files

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,10 +8,6 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# Not sure why I'm getting cannot-enumerate-pytest-fixtures failures:
-# https://github.com/reverbc/pylint-pytest/issues/20
-pylint-pytest==1.0.3
-
 # docutils is causing problems for sphinx_rtd_theme, but doc8 wants to force it
 # forward. Hold back doc8 while everyone resolves their issues.
 # https://github.com/readthedocs/sphinx_rtd_theme/issues/1323

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -38,6 +38,10 @@ certifi==2024.2.2
     # via
     #   -r requirements/quality.txt
     #   requests
+cffi==1.15.1
+    # via
+    #   -r requirements/quality.txt
+    #   cryptography
 chardet==5.2.0
     # via
     #   -r requirements/tox.txt
@@ -65,6 +69,10 @@ colorama==0.4.6
     #   tox
 coverage==7.2.7
     # via -r requirements/quality.txt
+cryptography==42.0.5
+    # via
+    #   -r requirements/quality.txt
+    #   secretstorage
 dill==0.3.7
     # via
     #   -r requirements/quality.txt
@@ -137,6 +145,11 @@ jedi==0.19.1
     # via
     #   -r requirements/quality.txt
     #   pudb
+jeepney==0.8.0
+    # via
+    #   -r requirements/quality.txt
+    #   keyring
+    #   secretstorage
 jinja2==3.1.3
     # via
     #   -r requirements/quality.txt
@@ -223,6 +236,10 @@ pudb==2022.1.3
     # via -r requirements/quality.txt
 pycodestyle==2.10.0
     # via -r requirements/quality.txt
+pycparser==2.21
+    # via
+    #   -r requirements/quality.txt
+    #   cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.txt
 pygments==2.17.2
@@ -237,7 +254,7 @@ pylint==2.17.7
     # via
     #   -r requirements/quality.txt
     #   pylint-pytest
-pylint-pytest==1.0.3
+pylint-pytest==1.1.7
     # via -r requirements/quality.txt
 pyproject-api==1.5.3
     # via
@@ -296,6 +313,10 @@ rich==13.7.1
     # via
     #   -r requirements/quality.txt
     #   twine
+secretstorage==3.3.3
+    # via
+    #   -r requirements/quality.txt
+    #   keyring
 six==1.16.0
     # via
     #   -r requirements/quality.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -29,6 +29,8 @@ certifi==2024.2.2
     #   -r requirements/doc.txt
     #   -r requirements/test.txt
     #   requests
+cffi==1.15.1
+    # via cryptography
 charset-normalizer==3.3.2
     # via
     #   -r requirements/doc.txt
@@ -52,6 +54,8 @@ coverage==7.2.7
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test.txt
+cryptography==42.0.5
+    # via secretstorage
 dill==0.3.7
     # via pylint
 doc8==0.11.2
@@ -113,6 +117,10 @@ jedi==0.19.1
     #   -r requirements/doc.txt
     #   -r requirements/test.txt
     #   pudb
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.3
     # via
     #   -r requirements/doc.txt
@@ -184,6 +192,8 @@ pudb==2022.1.3
     #   -r requirements/test.txt
 pycodestyle==2.10.0
     # via -r requirements/quality.in
+pycparser==2.21
+    # via cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.in
 pygments==2.17.2
@@ -199,7 +209,7 @@ pylint==2.17.7
     # via
     #   -r requirements/quality.in
     #   pylint-pytest
-pylint-pytest==1.0.3
+pylint-pytest==1.1.7
     # via -r requirements/quality.in
 pyproject-hooks==1.0.0
     # via build
@@ -251,6 +261,8 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.1
     # via twine
+secretstorage==3.3.3
+    # via keyring
 six==1.16.0
     # via
     #   -r requirements/doc.txt


### PR DESCRIPTION
This patch removes the `pylint-pytest` from the constraints.txt file. This change also updates the dependency to the version v1.1.7 in `requirements/dev.txt` and `requirements/quality.txt`.

Fixes #125 