### PR TITLE
Allow integer md_header_level

### DIFF
--- a/changelog.d/20250218_141622_makukha_90_md_header_level_should_be_read_as_an_int_in_toml_files.rst
+++ b/changelog.d/20250218_141622_makukha_90_md_header_level_should_be_read_as_an_int_in_toml_files.rst
@@ -1,0 +1,7 @@
+Added
+.....
+
+- Configuration setting ``md_header_level`` is allowed to be an integer in
+  TOML files, closing `issue 90`_.
+
+.. _issue 90: https://github.com/nedbat/scriv/issues/90

--- a/src/scriv/config.py
+++ b/src/scriv/config.py
@@ -121,8 +121,8 @@ class _Options:
     md_header_level = attr.ib(
         type=str,
         default="1",
-        validator=attr.validators.in_((*"123456", 1, 2, 3, 4, 5, 6)),
-        converter=str,
+        validator=attr.validators.matches_re(r"[123456]"),
+        converter=attr.converters.optional(str),
         metadata={
             "doc": """\
                 A number: for Markdown changelog files, this is the heading
@@ -353,7 +353,7 @@ class Config:
                 except KeyError:
                     pass
                 else:
-                    if attrdef.converter is not None:
+                    if callable(attrdef.converter):
                         val = attrdef.converter(val)
                     setattr(self._options, attrdef.name, val)
 

--- a/src/scriv/config.py
+++ b/src/scriv/config.py
@@ -121,7 +121,8 @@ class _Options:
     md_header_level = attr.ib(
         type=str,
         default="1",
-        validator=attr.validators.matches_re(r"[123456]"),
+        validator=attr.validators.in_((*"123456", 1, 2, 3, 4, 5, 6)),
+        converter=str,
         metadata={
             "doc": """\
                 A number: for Markdown changelog files, this is the heading
@@ -352,6 +353,8 @@ class Config:
                 except KeyError:
                     pass
                 else:
+                    if attrdef.converter is not None:
+                        val = attrdef.converter(val)
                     setattr(self._options, attrdef.name, val)
 
     def resolve_value(self, value: str) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,6 +66,7 @@ categories = [
     "Gone",
     "Bad",
 ]
+# other scriv options
 
 ["more stuff"]
 value = 17
@@ -344,6 +345,17 @@ class TestTomlConfig:
         with without_module(scriv.config, "tomllib"):
             config = Config.read()
         assert config.categories[0] == "Removed"
+
+    def test_nonstring_options(self, temp_dir):
+        # Some config options are allowed to be e.g. TOML integers; for these,
+        # both string and non-string values are valid.
+        marker = "# other scriv options"
+        for value in ('"6"', "6"):
+            custom = f"{marker}\nmd_header_level = {value}"
+            CUSTOM_TOML = TOML_CONFIG.replace(marker, custom)
+            (temp_dir / "pyproject.toml").write_text(CUSTOM_TOML)
+            config = Config.read()
+            assert config.md_header_level == "6"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -346,6 +346,7 @@ class TestTomlConfig:
             config = Config.read()
         assert config.categories[0] == "Removed"
 
+    @pytest.mark.skipif(tomllib is None, reason="No TOML support installed")
     def test_nonstring_options(self, temp_dir):
         # Some config options are allowed to be e.g. TOML integers; for these,
         # both string and non-string values are valid.


### PR DESCRIPTION
A simple change fixing #90.

I tried to be as conservative as possible, letting `md_header_level` remain `str` internally and be converted from `int` on input. This change is backwards compatible and allows string values as before.