### PR TITLE
Resolve a `DeprecationWarning` by adding a `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands =
     python -V
     pandoc --version
     no_extras: python -m pip uninstall -q -y tomli
-    coverage run -p -m pytest -Wd {posargs}
+    coverage run -p -m pytest -Wd -c setup.cfg {posargs}
 
 [testenv:coverage]
 depends = py39,py310,py311,py312,py313,pypy3


### PR DESCRIPTION
This resolves the following warning
when running `pip install -e.`:

```
DEPRECATION: Legacy editable install of scriv==1.5.1
from file:///path/to/scriv (setup.py develop)
is deprecated. pip 25.1 will enforce this behaviour
change. A possible replacement is to add a
pyproject.toml or enable --use-pep517, and use
setuptools >= 64. If the resulting installation is
not behaving as expected, try using --config-settings
editable_mode=compat. Please consult the setuptools
documentation for more information. Discussion can be
found at https://github.com/pypa/pip/issues/11457
```

Note that pytest must now be explicitly configured
to load its configuration from `setup.cfg`.
Otherwise, it will detect `pyproject.toml`
and attempt to import tomli, which is uninstalled
when the test suite is running the `-no_extras` factor.

It appears that scriv can still be packaged
by running `python -m build` after this change.

Closes #117

Fixed
-----

- Add a ``pyproject.toml`` file to resolve a ``DeprecationWarning``
  when installing the project in editable mode.