### PR TITLE
Allow hyphens in GitHub usernames/orgs/repos in a test suite regex

### DIFF
--- a/tests/test_gitinfo.py
+++ b/tests/test_gitinfo.py
@@ -76,5 +76,5 @@ def test_real_get_github_repos():
     repos = get_github_repos()
     assert len(repos) >= 1
     repo = repos.pop()
-    assert re.fullmatch(r"\w+/\w+", repo)
+    assert re.fullmatch(r"[\w-]+/[\w-]+", repo)
     assert not repo.endswith(".git")


### PR DESCRIPTION
I'm working to get the test suite passing locally -- it's been failing for multiple reasons, which has impaired my ability to thoroughly test other PRs I've submitted.

This PR addresses a bug in a regex in the test suite that disallowed hyphens in GitHub usernames/orgs/repos (like `kurtmckee/pr-scriv`).

Fixed
-----

- Fix a bug in a test suite regex that disallowed hyphens in GitHub usernames/orgs/repos.
