### PR TITLE
Ensure pip is available when running the `-no_extras` tox factor

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ package = wheel
 wheel_build_env = .pkg
 deps =
     -r{toxinidir}/requirements/test.txt
+    no_extras: pip
 extras =
     !no_extras: toml,yaml
 allowlist_externals =


### PR DESCRIPTION
I'm working to get the test suite passing locally -- it's been failing for multiple reasons, which has impaired my ability to thoroughly test other PRs I've submitted.

This PR addresses a missing pip dependency when using the `tox-uv` plugin; the tox environments are created without pip installed, which causes the `-no_extras` factors to fail. pip isn't added to the pip-compile-managed requirements files because pip-compile warns that "it is considered unsafe" to have pip listed in the requirements.


Fixed
-----

- Ensure that pip is available when running the ``-no_extras`` tox factor.
