### PR TITLE
Account for an upcoming behavioral change in pip-compile 8.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ docs: botedits ## generate Sphinx HTML documentation, including API docs
 	tox -e docs
 	$(BROWSER)docs/_build/html/index.html
 
-PIP_COMPILE = pip-compile --upgrade --resolver=backtracking
+PIP_COMPILE = pip-compile --upgrade --resolver=backtracking --no-strip-extras
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -qr requirements/pip-tools.txt


### PR DESCRIPTION
pip-compile throws a warning when running `make upgrade`:

> WARNING: --strip-extras is becoming the default in version 8.0.0.
> To silence this warning, either use --strip-extras
> to opt into the new default or use --no-strip-extras
> to retain the existing behavior.

This can be accounted for by adding the `--no-strip-extras` flag.

Fixed
-----

- Account for an upcoming behavioral change in pip-compile 8.0.0.
