### PR TITLE
Fix the invalid `scriv.user_nick` setting, which git rejects

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -419,7 +419,7 @@ User Nickname
 
 Scriv includes your git or GitHub username in the file names of changelog
 fragments you create.  If you don't like the name it finds for you, you can set
-a name as the ``scriv.user_nick`` git setting.
+customize the name using the ``scriv.user-nick`` git setting.
 
 
 .. _git config: https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration

--- a/src/scriv/gitinfo.py
+++ b/src/scriv/gitinfo.py
@@ -18,7 +18,7 @@ def user_nick() -> str:
     """
     Get a short name for the current user.
     """
-    nick = git_config("scriv.user_nick")
+    nick = git_config("scriv.user-nick")
     if nick:
         return nick
 

--- a/tests/test_gitinfo.py
+++ b/tests/test_gitinfo.py
@@ -6,7 +6,7 @@ from scriv.gitinfo import current_branch_name, get_github_repos, user_nick
 
 
 def test_user_nick_from_scriv_user_nick(fake_git):
-    fake_git.set_config("scriv.user_nick", "joedev")
+    fake_git.set_config("scriv.user-nick", "joedev")
     assert user_nick() == "joedev"
 
 


### PR DESCRIPTION
git rejects the `scriv.user_nick` setting because of the underscore.

If specified in a command like:

```
git config get scriv.user_nick
```

git will reject the name as invalid and fail with exit code 1.

If present in a git config file, git will fail to parse the file and fail with exit code 128.

The git reference manual has documented that only alphanumeric and hyphen characters are allowed since at least git 2.0.5, which was released in 2014 (11 years ago at the time of writing).

https://git-scm.com/docs/git-config/2.0.5#_configuration_file

No attempt has been made to provide backward compatibility with the `scriv.user_nick` setting (with an underscore) because it has been impossible for users to use the key name.

Fixes #130