### PR TITLE
Load config file from path when working with scriv

### DIFF
--- a/src/scriv/collect.py
+++ b/src/scriv/collect.py
@@ -6,9 +6,10 @@ from typing import Optional
 
 import click
 
+from .config import Config
 from .gitinfo import git_add, git_config_bool, git_edit, git_rm
 from .scriv import Scriv
-from .util import Version, scriv_command
+from .util import Version, scriv_command, config_option
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--version", default=None, help="The version name to use for this entry."
 )
+@config_option
 @scriv_command
 def collect(
     add: Optional[bool],
@@ -40,6 +42,7 @@ def collect(
     title: str,
     keep: bool,
     version: str,
+    config_file: Optional[str]
 ) -> None:
     """
     Collect and combine fragments into the changelog.
@@ -52,7 +55,11 @@ def collect(
     if edit is None:
         edit = git_config_bool("scriv.collect.edit")
 
-    scriv = Scriv()
+    if config_file is None:
+        scriv = Scriv()
+    else:
+        config = Config.read_config_file(config_file)
+        scriv = Scriv(config=config)
     logger.info(f"Collecting from {scriv.config.fragment_directory}")
     frags = scriv.fragments_to_combine()
     if not frags:

--- a/src/scriv/config.py
+++ b/src/scriv/config.py
@@ -304,6 +304,20 @@ class Config:
         return value
 
     @classmethod
+    def read_config_file(cls, config_file: str) -> Config:
+        """
+        Read a configuration file.
+
+        Configuration will be read from the given configuration file.
+        """
+        config = cls(post_create_=False)
+        config.read_one_config(config_file)
+        with validator_exceptions():
+            attr.validate(config._options)
+        config._options.post_create()
+        return config
+
+    @classmethod
     def read(cls) -> Config:
         """
         Read the configuration to use.

--- a/src/scriv/create.py
+++ b/src/scriv/create.py
@@ -8,7 +8,7 @@ import click
 
 from .gitinfo import git_add, git_config_bool, git_edit
 from .scriv import Scriv
-from .util import scriv_command
+from .util import scriv_command, config_option
 
 logger = logging.getLogger(__name__)
 
@@ -22,8 +22,9 @@ logger = logging.getLogger(__name__)
     default=None,
     help="Open the created file in your text editor.",
 )
+@config_option
 @scriv_command
-def create(add: Optional[bool], edit: Optional[bool]) -> None:
+def create(add: Optional[bool], edit: Optional[bool], config_file: Optional[str]) -> None:
     """
     Create a new changelog fragment.
     """
@@ -31,8 +32,12 @@ def create(add: Optional[bool], edit: Optional[bool]) -> None:
         add = git_config_bool("scriv.create.add")
     if edit is None:
         edit = git_config_bool("scriv.create.edit")
-
-    scriv = Scriv()
+    if config_file is None:
+        scriv = Scriv()
+    else:
+        from .config import Config
+        config = Config.read_config_file(config_file)
+        scriv = Scriv(config=config)
     frag = scriv.new_fragment()
     file_path = frag.path
     if not file_path.parent.exists():

--- a/src/scriv/print.py
+++ b/src/scriv/print.py
@@ -6,11 +6,13 @@ import logging
 import os
 import pathlib
 import sys
+from typing import Optional
 
 import click
 
+from .config import Config
 from .scriv import Scriv
-from .util import Version, scriv_command
+from .util import Version, scriv_command, config_option
 
 logger = logging.getLogger(__name__)
 
@@ -27,15 +29,21 @@ logger = logging.getLogger(__name__)
     default=None,
     help="The path to a file to write the output to.",
 )
+@config_option
 @scriv_command
 def print_(
     version: str | None,
     output: pathlib.Path | None,
+    config_file: Optional[str] = None,
 ) -> None:
     """
     Print collected fragments, or print an entry from the changelog.
     """
-    scriv = Scriv()
+    if config_file:
+        config = Config.read_config_file(config_file)
+        scriv = Scriv(config=config)
+    else:
+        scriv = Scriv()
     changelog = scriv.changelog()
     newline = os.linesep
 

--- a/src/scriv/util.py
+++ b/src/scriv/util.py
@@ -10,6 +10,7 @@ import sys
 from collections.abc import Sequence
 from typing import TypeVar
 
+import click
 import click_log
 
 from .exceptions import ScrivException
@@ -136,3 +137,11 @@ def scriv_command(func):
             sys.exit(str(exc))
 
     return _wrapped
+
+config_option = click.option(
+    "--config",
+    "config_file",
+    default=None,
+    type=click.Path(),
+    help="Use a custom config file.",
+)


### PR DESCRIPTION
This PR adds a new option `--config-file` to the cli commands create/collect/print/github-release.
It allows to load a config file from a given path.

This is useful if you need to work with different scriv configurations within one project.

### Examples
```shell
scriv create --edit --config-file /path/to/custom/scriv.ini
scriv collect --config-file /path/to/custom/scriv.ini
scriv print --config-file /path/to/custom/scriv.ini
scriv github-release --config-file /path/to/custom/scriv.ini
```